### PR TITLE
fix: Types were always set to place.other

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -4,17 +4,15 @@ var osmIsArea = require('osm-is-area')
 var varint = require('varint')
 
 module.exports = function (item, deps) {
-  var type
+  var type = 277
   if (Object.keys(item.tags).length !== 0){
     var tags = Object.entries(item.tags)
     tags.forEach(function (tagPair) {
       if (features[tagPair[0] + '.' + tagPair[1]]){
         type = features[tagPair[0] + '.' + tagPair[1]]
       }
-      else type = 277 //place.other
     })
   }
-  else type = 277 //place.other
   var id = item.id
 
   if (item.type === 'node') {


### PR DESCRIPTION
Found this bug -- type would always be set to place.other if there was more than one tag and the tag that set the type was not last.