### PR TITLE
fix: Use proper length for number of total cells in area encoder

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -23,7 +23,7 @@ module.exports = function (item, deps) {
     var labelLen = getLabelLen(item.tags)
     var buf = Buffer.alloc(9 + typeLen + idLen + labelLen)
     var offset = 0
-    buf.writeUInt8(0x01, offset) 
+    buf.writeUInt8(0x01, offset)
     offset+=1
     varint.encode(type, buf, offset)
     offset+=varint.encode.bytes
@@ -47,16 +47,11 @@ module.exports = function (item, deps) {
         coords.push(deps[ref].lat)
       })
       var cells = earcut(coords)
-      var coords = []
-      item.refs.forEach(function (ref) {
-        coords.push(deps[ref].lon)
-        coords.push(deps[ref].lat)
-      })
-      var cells = earcut(coords)
-      var cLen = varint.encodingLength(earcut.length/3)
+      var cLen = varint.encodingLength(cells.length/3)
+      var cLenData = cells.reduce((acc, cell) => acc + varint.encodingLength(cell), 0)
       var labelLen = getLabelLen(item.tags)
       var buf = Buffer.alloc(1 + typeLen + idLen + pCount + cLen + n*4*2
-        + (n-2)*3*2 + labelLen)
+        + cLenData + labelLen)
       var offset = 0
       buf.writeUInt8(0x03, 0)
       offset+=1
@@ -74,8 +69,8 @@ module.exports = function (item, deps) {
       })
       varint.encode(cells.length/3, buf, offset)
       offset+=varint.encode.bytes
-      cells.forEach(function (item) {
-        varint.encode(item, buf, offset)
+      cells.forEach(function (cell) {
+        varint.encode(cell, buf, offset)
         offset+=varint.encode.bytes
       })
       writeLabelData(item.tags, buf, offset)
@@ -117,7 +112,7 @@ function getLabelLen (tags) {
     if (!/^([^:]+_|)name($|:)/.test(key)) { return }
     var pre = key.replace(/^(|[^:]+_)name($|:)/,'')
     var dataLen = Buffer.byteLength(pre) + 1
-      + Buffer.byteLength(tags[key]) 
+      + Buffer.byteLength(tags[key])
     labelLen += varint.encodingLength(dataLen) + dataLen
   })
   return labelLen

--- a/example/encode.js
+++ b/example/encode.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var through = require('through2')
 var parseOSM = require('osm-pbf-parser')
 var georenderPack = require('../encode.js')
- 
+
 var osm = parseOSM()
 var allItems = {}
 var itemsRefsObject = {}


### PR DESCRIPTION
For a simple area with 3 nodes, I ran the encoder and got a lot of zeros at the end using the latest code on the master branch. (I can send this file to you in a gist if you want). 

Looking at the code, it seems like there is a calculation for the size of an area which I don't entirely understand. It seems like it should allocate for the # of cells encoded as varints? I'm not exactly sure what the old code was calculating -- if we need it, probably best we add a bit of documentation or comment about the :mage: magic :star2: numbers :+1: :smile: 

EDIT: it isn't a big deal, I *think* if the length is too long.. then the output could just be trimmed once it's determined that the cell length is actually smaller than predicted.

Before:

```
03950283e4da06041983c7c26f1623421683c7c2251723421583c7c2f51823421983c7c26f162342010200010e3d4a616d656c277320486f75736500000000000000000000
```

After:

```
03950283e4da06041983c7c26f1623421683c7c2251723421583c7c2f51823421983c7c26f162342010200010e3d4a616d656c277320486f75736500
```